### PR TITLE
feat: 공동현관 상태에 따라 RDS에 자동 로그 남기기

### DIFF
--- a/devices/entrance/src/entrance/entrance.cpp
+++ b/devices/entrance/src/entrance/entrance.cpp
@@ -100,6 +100,12 @@ void Entrance::waitForCard()
 		if (rc522.PICC_IsNewCardPresent() && rc522.PICC_ReadCardSerial()) 
 		{
 			Serial.println("[DEBUG] {waitForCard} Card detected!");
+			m_card_uid_size = rc522.uid.size;
+			for (byte i = 0; i < m_card_uid_size; i++) 
+			{
+				m_card_uid[i] = rc522.uid.uidByte[i];
+			}
+
 			Serial.print("Card UID: ");
 			for (byte i = 0; i < rc522.uid.size; i++) 
 			{
@@ -119,6 +125,12 @@ void Entrance::closeDoor()
 	m_is_detected = false;
 	m_is_valid = false;
 	stepper.step(-MOTOR_STEPS);
+
+	digitalWrite(STEP_INT4, LOW);
+	digitalWrite(STEP_INT2, LOW);
+	digitalWrite(STEP_INT3, LOW);
+	digitalWrite(STEP_INT1, LOW);
+
 	Serial.println("[DEBUG] Door closed");
 }
 
@@ -249,7 +261,16 @@ void Entrance::createLog(EVENT_TYPE type)
 {	
 	Serial.print(eventTypeToString(type));
 	Serial.print(",");
-	Serial.println(m_entrance_device_id);
+	Serial.print(m_entrance_device_id);
+	Serial.print(",");
+	
+	// UID 출력 (HEX 형식)
+	for (byte i = 0; i < m_card_uid_size; i++) 
+	{
+		if (m_card_uid[i] < 0x10) Serial.print("0");
+		Serial.print(m_card_uid[i], HEX);
+	}
+	Serial.println();
 }
 
 void Entrance::set_device_id()

--- a/devices/entrance/src/entrance/entrance.h
+++ b/devices/entrance/src/entrance/entrance.h
@@ -32,6 +32,8 @@ private:
 	unsigned long m_open_time;
 	bool m_is_detected;
 	bool m_is_valid;
+	byte m_card_uid[10];
+	byte m_card_uid_size;
 
 	MFRC522::StatusCode checkAuth(int index, MFRC522::MIFARE_Key key);
 	void toBytes(byte* buffer, int data, int offset = 0);


### PR DESCRIPTION
### 작업  내용
- [x] 공동현관 관련 로그를 Serial로 정리
- [x] python 파이프라인을 활용해 Serial 내용을 RDB로 정리
- [x] 테이블 중 device id 컬럼은 기기별 chip id 사용
- [x] uid도 저장하도록 수정
- [x] 멤버변수 네이밍이 컨벤션에 맞도록 수정